### PR TITLE
split processing turned off for load-dataset-from-pkg dialog

### DIFF
--- a/loadDatasetFromPackage.js
+++ b/loadDatasetFromPackage.js
@@ -59,6 +59,7 @@ class loadDatasetFromPackage extends baseModal {
         var config = {
             id: "loadDatasetFromPackage",
             label: localization.en.title,
+			splitProcessing: false,
             modalType: "one",
             RCode: `
 require(utils)


### PR DESCRIPTION
Steps to replicate:
load dataset and split a factor.
Keeping this dataset active, load dataset from package, you will see various levels of the variable that had split in the first dataset, you loaded.